### PR TITLE
verify MP3s

### DIFF
--- a/lib/aur/commands/verify.rb
+++ b/lib/aur/commands/verify.rb
@@ -10,6 +10,18 @@ module Aur
     # what we call 'linting'.
     #
     class Verify < Base
+      include Aur::Renamers
+
+      def equipped?
+        abort "No #{binary} binary." unless BIN[binary].exist?
+      end
+
+      def report(valid)
+        puts format('%<name>-70s  %<status>s',
+                    name: info.file,
+                    status: valid ? 'OK' : 'INVALID')
+      end
+
       def self.help
         <<~EOUSAGE
           usage: aur verify <file>...
@@ -23,24 +35,28 @@ module Aur
     # Verify FLACs.
     #
     module VerifyFlac
-      include Aur::Renamers
+      def binary
+        :flac
+      end
 
       def run
-        abort 'No flac binary.' unless BIN[:flac].exist?
-
         res = system("#{BIN[:flac]} --test --totally-silent #{escaped(file)}")
-
-        puts format('%<name>-60s  %<status>s',
-                    name: info.prt_name,
-                    status: res ? 'OK' : 'INVALID')
+        report(res)
       end
     end
 
     # We can't verify MP3s, but we can at least say so.
     #
     module VerifyMp3
+      def binary
+        :mp3val
+      end
+
       def run
-        warn 'MP3 files cannot be verified.'
+        abort 'No mp3val binary.' unless BIN[:mp3val].exist?
+
+        res = `#{BIN[:mp3val]} #{escaped(file)}`
+        report(!res.include?('WARNING'))
       end
     end
   end

--- a/lib/aur/constants.rb
+++ b/lib/aur/constants.rb
@@ -13,7 +13,7 @@ BIN_DIR = if BIN_DIRS.exist?
 
 SUPPORTED_TYPES = %w[flac mp3].freeze
 
-BIN = %i[ffmpeg flac lame metaflac shnsplit convert].to_h do |f|
+BIN = %i[ffmpeg flac lame metaflac shnsplit convert mp3val].to_h do |f|
   [f, BIN_DIR.join(f.to_s)]
 end
 

--- a/spec/aur/commands/verify_functional_spec.rb
+++ b/spec/aur/commands/verify_functional_spec.rb
@@ -19,14 +19,8 @@ class TestVerifyCmd < Minitest::Test
   end
 
   def test_flac_verify
-    assert_output(/^bad_name.flac\s+OK$/, '') do
+    assert_output(/bad_name.flac\s+OK$/, '') do
       Aur::Action.new(:verify, [RES_DIR.join('bad_name.flac')]).run!
-    end
-  end
-
-  def test_mp3_verify
-    assert_output('', "MP3 files cannot be verified.\n") do
-      Aur::Action.new(:verify, [RES_DIR.join('bad_name.mp3')]).run!
     end
   end
 


### PR DESCRIPTION
Verify MP3s with `mp3val`, if we have it. It throws a lot of false positives, but it does catch broken stuff.