### PR TITLE
remove default syncflac option

### DIFF
--- a/bin/aur
+++ b/bin/aur
@@ -70,7 +70,7 @@ docopt = <<~EOCMDS
     aur verify <file>...
     aur flac2mp3 <file>...
     aur mp3dir [-rf] <directory>...
-    aur syncflac [-D]
+    aur syncflac
     aur wantflac [-T]
     aur transcode <newtype> <file>...
     aur reencode <file>...
@@ -99,7 +99,6 @@ docopt = <<~EOCMDS
     -f, --force         overwrite any existing files
     -m, --forcemod      modify MP3 tags if corresponding FLAC has a newer mtime
     -N, --novalidate    don't validate tags
-    -D, --deep          synchronize contents of all FLAC directories
 EOCMDS
 
 def sanitize_keys(options)

--- a/lib/aur/commands/mixins/file_tree.rb
+++ b/lib/aur/commands/mixins/file_tree.rb
@@ -8,7 +8,7 @@ module Aur
     # Methods to help deal with files in our expected hierarchy
     #
     module FileTree
-      # @param dir [Pathname] top-level directory
+      # @param root [Pathname] top-level directory
       # @param suffix [String] filetype suffix with leading dot
       # @return [Array[Array[Pathname, Int]]] arrays pairing relative path of
       #   a content directory with the number of audio files inside it
@@ -27,6 +27,16 @@ module Aur
                 .select(&:file?)
                 .select { |f| f.extname == suffix }
                 .to_h { |f| [f, f.no_tnum] }
+      end
+
+      # @param root [Pathname] top level directory
+      # @param omit_list [Array[String]] list of directories, relative to
+      #   @root, that you wish to be omitted from the @return
+      # @return [Array[Pathname]] of directories under the given root
+      #
+      def dirs_under(root, omit_list = [])
+        all = Pathname.glob("#{root}/**/*").select(&:directory?)
+        all - omit_list.map { |d| root.join(d) }
       end
     end
   end

--- a/spec/aur/commands/mixins/file_tree_spec.rb
+++ b/spec/aur/commands/mixins/file_tree_spec.rb
@@ -38,4 +38,14 @@ class Test < Minitest::Test
       result.key('fall.free_ranger.flac')
     )
   end
+
+  def test_dirs_under
+    all = dirs_under(TEST_DIR)
+    assert all.all?(&:directory?)
+    assert_includes(all, TEST_DIR.join('fall.eds_babe'))
+
+    selected = dirs_under(TEST_DIR, ['fall.eds_babe'])
+    assert selected.all?(&:directory?)
+    refute_includes(selected, TEST_DIR.join('fall.eds_babe'))
+  end
 end

--- a/spec/aur/commands/syncflac_spec.rb
+++ b/spec/aur/commands/syncflac_spec.rb
@@ -6,28 +6,4 @@ require_relative '../../../lib/aur/commands/syncflac'
 
 # Tests for syncflac class
 #
-class TestSyncflac < Minitest::Test
-  def test_difference
-    t = Aur::Command::Syncflac.new(RES_DIR.join('syncflac'))
-
-    assert_equal(
-      [RES_DIR.join('syncflac/flac/albums/abc/artist.album_1'),
-       RES_DIR.join('syncflac/flac/eps/band.ep_1'),
-       RES_DIR.join('syncflac/flac/eps/band.ep_2'),
-       RES_DIR.join('syncflac/flac/tracks')],
-      t.difference(t.flacs, t.mp3s)
-    )
-
-    t = Aur::Command::Syncflac.new(RES_DIR.join('lintdir'))
-
-    assert_equal(
-      [RES_DIR.join('lintdir/flac/fall.eds_babe'),
-       RES_DIR.join('lintdir/flac/slint.spiderland_remastered'),
-       RES_DIR.join('lintdir/flac/slint.spiderland_remastered/bonus_disc'),
-       RES_DIR.join('lintdir/flac/tester.different_album'),
-       RES_DIR.join('lintdir/flac/tester.different_genre'),
-       RES_DIR.join('lintdir/flac/tester.different_year')],
-      t.difference(t.flacs, t.mp3s)
-    )
-  end
-end
+class TestSyncflac < Minitest::Test; end


### PR DESCRIPTION
Make syncflac always sync everything, because that's all I ever do. Why would it do anything else?